### PR TITLE
Build: Credentials file removed and credentials created in GCP

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 
 spring.cloud.gcp.sql.database-name=hyperlocal
 spring.cloud.gcp.sql.instance-connection-name=speedy-anthem-217710:us-central1:hyperlocal
-#Change this to point to your file:<your_credentials_file_path> 
-spring.cloud.gcp.credentials.location=classpath:cred.json
+#Uncomment in dev and point to your file:<your_credentials_file_path> 
+#spring.cloud.gcp.credentials.location=classpath:cred.json

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <title>Hyperlocal Project</title>
+  </head>
+  <body>
+    Hi
+  </body>
+</html>


### PR DESCRIPTION
I commented out the link to credential file for deployment to GCP. The build was failing because it couldn't find credentials file. I have added credentials in GCP environment and deleted the part to include credentials from file in code. 