### PR TITLE
Fix: Change Datatype of merchantID to String

### DIFF
--- a/schema/merchants.ddl
+++ b/schema/merchants.ddl
@@ -1,5 +1,5 @@
 CREATE TABLE `Merchants` (
-  `MerchantID` VARCHAR(30) NOT NULL,
+  `MerchantID` VARCHAR(255) NOT NULL,
   `MerchantName` VARCHAR(255) NOT NULL,  
   `MerchantPhone` VARCHAR(20) NOT NULL,
   PRIMARY KEY(`MerchantID`)

--- a/schema/merchants.ddl
+++ b/schema/merchants.ddl
@@ -1,5 +1,5 @@
 CREATE TABLE `Merchants` (
-  `MerchantID` BIGINT NOT NULL,
+  `MerchantID` VARCHAR(30) NOT NULL,
   `MerchantName` VARCHAR(255) NOT NULL,  
   `MerchantPhone` VARCHAR(10) NOT NULL,
   PRIMARY KEY(`MerchantID`)

--- a/schema/merchants.ddl
+++ b/schema/merchants.ddl
@@ -1,6 +1,6 @@
 CREATE TABLE `Merchants` (
   `MerchantID` VARCHAR(30) NOT NULL,
   `MerchantName` VARCHAR(255) NOT NULL,  
-  `MerchantPhone` VARCHAR(10) NOT NULL,
+  `MerchantPhone` VARCHAR(20) NOT NULL,
   PRIMARY KEY(`MerchantID`)
 );

--- a/schema/shops.ddl
+++ b/schema/shops.ddl
@@ -1,6 +1,6 @@
 CREATE TABLE `Shops` (
   `ShopID` BIGINT NOT NULL,
-  `MerchantID` VARCHAR(30) NOT NULL,
+  `MerchantID` VARCHAR(255) NOT NULL,
   `ShopName` VARCHAR(255) NOT NULL,
   `Latitude` DECIMAL(10, 8) NOT NULL,
   `Longitude` DECIMAL(11, 8) NOT NULL,

--- a/schema/shops.ddl
+++ b/schema/shops.ddl
@@ -1,6 +1,6 @@
 CREATE TABLE `Shops` (
   `ShopID` BIGINT NOT NULL,
-  `MerchantID` BIGINT NOT NULL,
+  `MerchantID` VARCHAR(30) NOT NULL,
   `ShopName` VARCHAR(255) NOT NULL,
   `Latitude` DECIMAL(10, 8) NOT NULL,
   `Longitude` DECIMAL(11, 8) NOT NULL,

--- a/src/main/java/com/hyperlocal/server/Data/Merchant.java
+++ b/src/main/java/com/hyperlocal/server/Data/Merchant.java
@@ -4,7 +4,7 @@ import com.github.jasync.sql.db.RowData;
 import com.google.gson.JsonObject;
 
 public class Merchant {
-  public Long merchantID;
+  public String merchantID;
   public String merchantName;
   public String merchantPhone;
 
@@ -14,25 +14,25 @@ public class Merchant {
     this.merchantPhone = null;
   }
 
-  public Merchant(Long merchantID, String merchantName, String merchantPhone) {
+  public Merchant(String merchantID, String merchantName, String merchantPhone) {
     this.merchantID = merchantID;
     this.merchantName = merchantName;
     this.merchantPhone = merchantPhone;
   }
 
   public Merchant(RowData data) {
-    this.merchantID = (Long) data.get("MerchantID");
+    this.merchantID = (String) data.get("MerchantID");
     this.merchantName = (String) data.get("MerchantName");
     this.merchantPhone = (String) data.get("MerchantPhone");
   }
 
   public Merchant(JsonObject data) {
-    this.merchantID = data.get("merchantID").getAsLong();
+    this.merchantID = data.get("merchantID").getAsString();
     this.merchantName = data.get("merchantName").getAsString();
     this.merchantPhone = data.get("merchantPhone").getAsString();
   }
 
-  public Long getMerchantID() {
+  public String getMerchantID() {
     return merchantID;
   }
 

--- a/src/main/java/com/hyperlocal/server/Data/Shop.java
+++ b/src/main/java/com/hyperlocal/server/Data/Shop.java
@@ -7,13 +7,13 @@ import java.math.BigDecimal;
 
 public class Shop {
     public Long shopID;
-    public Long merchantID;
+    public String merchantID;
     public String shopName, addressLine1, typeOfService;
     public Double latitude, longitude;
     
     public Shop() {
       this.shopID = 1L;
-      this.merchantID = 1L;
+      this.merchantID = "1";
       this.shopName = "Test";
       this.addressLine1 = "TEST";
       this.typeOfService = "TEST";
@@ -21,7 +21,7 @@ public class Shop {
       this.longitude = 32.32;
     }
 
-    public Shop(Long shopID, Long merchantID, String shopName, Double latitude, Double longitude, String addressLine1, String typeOfService)
+    public Shop(Long shopID, String merchantID, String shopName, Double latitude, Double longitude, String addressLine1, String typeOfService)
     {
         this.shopID = shopID;
         this.merchantID = merchantID;
@@ -35,7 +35,7 @@ public class Shop {
     public Shop(RowData data)
     {
         this.shopID = (Long)data.get("ShopID");
-        this.merchantID = (Long)data.get("MerchantID");
+        this.merchantID = (String)data.get("MerchantID");
         this.shopName = (String)data.get("ShopName");
         this.latitude = ((BigDecimal)data.get("Latitude")).doubleValue();
         this.longitude = ((BigDecimal)data.get("Longitude")).doubleValue();
@@ -45,7 +45,7 @@ public class Shop {
 
     public Shop(JsonObject data) {
       this.shopID = data.get("shopID").getAsLong();
-      this.merchantID = data.get("merchantID").getAsLong();
+      this.merchantID = data.get("merchantID").getAsString();
       this.shopName = data.get("shopName").getAsString();
       this.addressLine1 = data.get("addressLine1").getAsString();
       this.typeOfService = data.get("typeOfService").getAsString();

--- a/src/main/java/com/hyperlocal/server/ShopController.java
+++ b/src/main/java/com/hyperlocal/server/ShopController.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 
 import com.github.jasync.sql.db.Connection;
 import com.github.jasync.sql.db.QueryResult;
@@ -19,7 +20,6 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
-
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -43,8 +43,11 @@ public class ShopController {
   private static final String SHOP_INSERT_STATEMENT = "INSERT INTO `Shops` (`ShopName`, `TypeOfService`, `Latitude`, `Longitude`, `AddressLine1`, `MerchantID`) VALUES (?,?,?,?,?,?);";;
   private static final String SELECT_SHOP_STATEMENT = "SELECT `ShopID`, `MerchantID`, `ShopName`, `Latitude`, `Longitude`, `AddressLine1`, `TypeOfService` from `Shops` WHERE `ShopID` = ?;";
   private static final String SELECT_SHOPS_BY_MERCHANT_STATEMENT = "SELECT `ShopID`, `MerchantID`, `ShopName`, `Latitude`, `Longitude`, `AddressLine1`, `TypeOfService` from `Shops` WHERE `MerchantID` = ?;";
+  private static final String SELECT_SHOPS_BATCH_QUERY = "SELECT `ShopID`, `MerchantID`, `ShopName`, `Latitude`, `Longitude`, `AddressLine1`, `TypeOfService` from `Shops` WHERE `ShopID` IN (%s);";
   private static final String SELECT_MERCHANT_STATEMENT = "SELECT `MerchantID`, `MerchantName`, `MerchantPhone` from `Merchants` WHERE `MerchantID` = ?;";
+  private static final String SELECT_MERCHANT_BATCH_QUERY = "SELECT `MerchantID`, `MerchantName`, `MerchantPhone` from `Merchants` WHERE `MerchantID` IN (%s);";
   private static final String SELECT_CATALOG_BY_SHOP_STATEMENT = "SELECT `ServiceID`, `ShopID`, `ServiceName`, `ServiceDescription`, `ImageURL` from `Catalog` WHERE `ShopID` = ?;";
+  private static final String SELECT_CATALOG_BATCH_QUERY = "SELECT `ServiceID`, `ShopID`, `ServiceName`, `ServiceDescription`, `ImageURL` from `Catalog` WHERE `ShopID` IN (%s);";
   private static final String INSERT_CATALOG_STATEMENT = "INSERT INTO `Catalog` (`ShopID`, `ServiceName`, `ServiceDescription`, `ImageURL`) VALUES (?, ?, ?, ?);";
   private static final String UPDATE_CATALOG_STATEMENT = "UPDATE `Catalog` SET `ServiceName` = ?, `ServiceDescription` = ?, `ImageURL` = ? WHERE `ServiceID` = ?;";
   private static final String DELETE_CATALOG_STATEMENT = "DELETE FROM `Catalog` WHERE `ServiceID` = ?;";
@@ -56,10 +59,9 @@ public class ShopController {
     connection = MySQLConnectionBuilder.createConnectionPool(DATABASE_URL);
   }
 
-  /* To-do server-side checks: 
-  - Access control
-  - Data validation */
-
+  /*
+   * To-do server-side checks: - Access control - Data validation
+   */
 
   // Fetch all shops by merchantID
   @GetMapping("/api/merchant/{merchantID}/shops")
@@ -68,20 +70,82 @@ public class ShopController {
 
     CompletableFuture<List<Shop>> shopsPromise = connection
         // Get associated shops
-      .sendPreparedStatement(SELECT_SHOPS_BY_MERCHANT_STATEMENT, Arrays.asList(merchantID))
-      .thenApply((QueryResult shopQueryResult) -> {
-        ResultSet shopRecords = shopQueryResult.getRows();
-        for(RowData shopRecord : shopRecords) shopsList.add(new Shop(shopRecord));
-        return shopsList;
-        
-      }).exceptionally(ex -> {
-        logger.error("Executed exceptionally: getShopsByMerchantID()", ex);
-        throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage(), ex);
-      });
+        .sendPreparedStatement(SELECT_SHOPS_BY_MERCHANT_STATEMENT, Arrays.asList(merchantID))
+        .thenApply((QueryResult shopQueryResult) -> {
+          ResultSet shopRecords = shopQueryResult.getRows();
+          for (RowData shopRecord : shopRecords)
+            shopsList.add(new Shop(shopRecord));
+          return shopsList;
+
+        }).exceptionally(ex -> {
+          logger.error("Executed exceptionally: getShopsByMerchantID()", ex);
+          throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage(), ex);
+        });
 
     return shopsPromise;
   }
 
+  @GetMapping("/api/shops/multiple")
+  public CompletableFuture<List<ShopDetails>> getShopsByShopIDBatch() {
+    List<ShopDetails> shopsList = new ArrayList<ShopDetails>();
+
+    List<Long> shopIDList = new ArrayList<Long>();
+    shopIDList.add(1L);
+    shopIDList.add(2L);
+    shopIDList.add(3L);
+
+    HashMap<Long, Shop> mapShopIdtoShop = new HashMap<Long, Shop>();
+    HashMap<String, Merchant> mapMerchantIdToMerchant = new HashMap<String, Merchant>();;
+    HashMap<Long, ShopDetails> mapShopIdToShopDetails = new HashMap<Long, ShopDetails>();;
+
+    // Convert ShopIDs to a String separated by Comma
+    String shopIDListAsString = shopIDList.stream().map(Object::toString).collect(Collectors.joining(","));
+
+    System.out.println(shopIDListAsString);
+    return connection.sendPreparedStatement(String.format(SELECT_SHOPS_BATCH_QUERY, shopIDListAsString))
+        .thenApply((QueryResult result) -> {
+          List<String> merchantIDList = new ArrayList<String>();
+          ResultSet allShops = result.getRows();
+          for (RowData shop : allShops) {
+            mapShopIdtoShop.put((Long) shop.get("ShopID"), new Shop(shop));
+            mapShopIdToShopDetails.put((Long) shop.get("ShopID"), new ShopDetails());
+
+            merchantIDList.add((String) shop.get("MerchantID"));
+          }
+          return merchantIDList;
+     
+     
+        }).thenCompose((merchantIDList) -> {
+          String MerchantIDListAsString = merchantIDList.stream().map(Object::toString).collect(Collectors.joining(","));
+          return connection.sendPreparedStatement(String.format(SELECT_MERCHANT_BATCH_QUERY, MerchantIDListAsString));
+        }).thenApply((result) -> {
+          ResultSet allMerchants = result.getRows();
+          for (RowData merchant : allMerchants) {
+            mapMerchantIdToMerchant.put((String) merchant.get("MerchantID"), new Merchant(merchant));
+          }
+          return allMerchants;
+     
+     
+        }).thenCompose((allMerchants) -> {
+          return connection.sendPreparedStatement(String.format(SELECT_CATALOG_BATCH_QUERY, shopIDListAsString));
+        }).thenApply((catalogQueryResult) -> {
+          ResultSet catalogRecords = catalogQueryResult.getRows();
+          for (RowData serviceRecord : catalogRecords) {
+            Long ShopID = (Long) serviceRecord.get("ShopID");
+            ShopDetails shopDetails = mapShopIdToShopDetails.get(ShopID);
+            Shop shop = mapShopIdtoShop.get(ShopID);
+            shopDetails.setShop(mapShopIdtoShop.get(ShopID));
+            shopDetails.setMerchant(mapMerchantIdToMerchant.get(shop.merchantID));
+            shopDetails.addCatalogItem(new CatalogItem(serviceRecord));
+            mapShopIdToShopDetails.put(ShopID, shopDetails);
+          }
+
+          for (Long ShopId : shopIDList) {
+            shopsList.add(mapShopIdToShopDetails.get(ShopId));
+          }
+          return shopsList;
+        });
+  }
 
   // Fetch catalog, shop & merchant details by shopID.
   @GetMapping("/api/shop/{shopID}")
@@ -91,89 +155,91 @@ public class ShopController {
 
     CompletableFuture<ShopDetails> shopDetailsPromise = connection
         // Get Shop details:
-      .sendPreparedStatement(SELECT_SHOP_STATEMENT, Arrays.asList(shopID))
-      .thenCompose((QueryResult shopQueryResult) -> {
-        ResultSet wrappedShopRecord = shopQueryResult.getRows();
-        if(wrappedShopRecord.size() == 0) throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Requested shop was not found.");
-        RowData shopRecord = wrappedShopRecord.get(0);
-        shopDetails.setShop(new Shop(shopRecord));
+        .sendPreparedStatement(SELECT_SHOP_STATEMENT, Arrays.asList(shopID))
+        .thenCompose((QueryResult shopQueryResult) -> {
+          ResultSet wrappedShopRecord = shopQueryResult.getRows();
+          if (wrappedShopRecord.size() == 0)
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Requested shop was not found.");
+          RowData shopRecord = wrappedShopRecord.get(0);
+          shopDetails.setShop(new Shop(shopRecord));
 
-        // Get Merchant Details:
-        return connection.sendPreparedStatement(SELECT_MERCHANT_STATEMENT, Arrays.asList(shopDetails.shop.merchantID));
-      }).thenCompose((QueryResult merchantQueryResult) -> {
-        ResultSet wrappedMerchantRecord = merchantQueryResult.getRows();
-        if(wrappedMerchantRecord.size() == 0) throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Something went wrong. No merchant found for the shop.");
-        shopDetails.setMerchant(new Merchant(wrappedMerchantRecord.get(0)));
-        
-        // Get Catalog Details:
-        return connection.sendPreparedStatement(SELECT_CATALOG_BY_SHOP_STATEMENT, Arrays.asList(shopID));
-      }).thenApply((QueryResult catalogQueryResult) -> {
-        ResultSet catalogRecords = catalogQueryResult.getRows();
-        for(RowData serviceRecord : catalogRecords) shopDetails.addCatalogItem(new CatalogItem(serviceRecord));
-        return shopDetails;
-        
-      });
+          // Get Merchant Details:
+          return connection.sendPreparedStatement(SELECT_MERCHANT_STATEMENT,
+              Arrays.asList(shopDetails.shop.merchantID));
+        }).thenCompose((QueryResult merchantQueryResult) -> {
+          ResultSet wrappedMerchantRecord = merchantQueryResult.getRows();
+          if (wrappedMerchantRecord.size() == 0)
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+                "Something went wrong. No merchant found for the shop.");
+          shopDetails.setMerchant(new Merchant(wrappedMerchantRecord.get(0)));
+
+          // Get Catalog Details:
+          return connection.sendPreparedStatement(SELECT_CATALOG_BY_SHOP_STATEMENT, Arrays.asList(shopID));
+        }).thenApply((QueryResult catalogQueryResult) -> {
+          ResultSet catalogRecords = catalogQueryResult.getRows();
+          for (RowData serviceRecord : catalogRecords)
+            shopDetails.addCatalogItem(new CatalogItem(serviceRecord));
+          return shopDetails;
+
+        });
 
     return shopDetailsPromise;
   }
 
-
   @PostMapping("/api/shop/{shopID}/catalog/update")
-  public CompletableFuture<HashMap<String, Object>> upsertCatalog(@PathVariable Long shopID, @RequestBody String updatePayload) {
+  public CompletableFuture<HashMap<String, Object>> upsertCatalog(@PathVariable Long shopID,
+      @RequestBody String updatePayload) {
     JsonObject commands = JsonParser.parseString(updatePayload).getAsJsonObject();
     JsonArray addCommands = commands.getAsJsonArray("add");
     JsonArray editCommands = commands.getAsJsonArray("edit");
     JsonArray delCommands = commands.getAsJsonArray("delete");
     CompletableFuture<QueryResult> statusPromise = connection.sendQuery("BEGIN");
-    
+
     // Process add commands
-    for(JsonElement addCommandRaw : addCommands)
-    {
+    for (JsonElement addCommandRaw : addCommands) {
       statusPromise = statusPromise.thenCompose((QueryResult result) -> {
         JsonObject addCommand = addCommandRaw.getAsJsonObject();
         String serviceName = addCommand.get("serviceName").getAsString();
         String serviceDescription = addCommand.get("serviceDescription").getAsString();
         String imageURL = addCommand.get("imageURL").getAsString();
-        return connection.sendPreparedStatement(INSERT_CATALOG_STATEMENT, Arrays.asList(shopID, serviceName, serviceDescription, imageURL));
+        return connection.sendPreparedStatement(INSERT_CATALOG_STATEMENT,
+            Arrays.asList(shopID, serviceName, serviceDescription, imageURL));
       });
     }
 
     // Process edit commands
-    for(JsonElement editCommandRaw : editCommands)
-    {
+    for (JsonElement editCommandRaw : editCommands) {
       statusPromise = statusPromise.thenCompose((QueryResult result) -> {
         JsonObject editCommand = editCommandRaw.getAsJsonObject();
         Long serviceID = editCommand.get("serviceID").getAsLong();
         String serviceName = editCommand.get("serviceName").getAsString();
         String serviceDescription = editCommand.get("serviceDescription").getAsString();
         String imageURL = editCommand.get("imageURL").getAsString();
-        return connection.sendPreparedStatement(UPDATE_CATALOG_STATEMENT, Arrays.asList(serviceName, serviceDescription, imageURL, serviceID));
+        return connection.sendPreparedStatement(UPDATE_CATALOG_STATEMENT,
+            Arrays.asList(serviceName, serviceDescription, imageURL, serviceID));
       });
     }
 
     // Process delete commands
-    for(JsonElement delCommandRaw : delCommands)
-    {
+    for (JsonElement delCommandRaw : delCommands) {
       statusPromise = statusPromise.thenCompose((QueryResult result) -> {
         Long serviceID = delCommandRaw.getAsJsonObject().get("serviceID").getAsLong();
         return connection.sendPreparedStatement(DELETE_CATALOG_STATEMENT, Arrays.asList(serviceID));
       });
     }
-    
-    return statusPromise
-      .thenCompose((QueryResult result) -> {
-        // If successful, commit
-        return connection.sendQuery("COMMIT");
-      }).thenApply((QueryResult result) -> {
-        HashMap<String, Object> successMap = new HashMap<String, Object>();
-        successMap.put("success", true);
-        return successMap;
-      })
-      .exceptionally((ex) -> {
-        // Else, auto-rollback when connection closes
-        logger.error("Executed exceptionally: upsertCatalog()", ex);
-        throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage(), ex);
-      });
+
+    return statusPromise.thenCompose((QueryResult result) -> {
+      // If successful, commit
+      return connection.sendQuery("COMMIT");
+    }).thenApply((QueryResult result) -> {
+      HashMap<String, Object> successMap = new HashMap<String, Object>();
+      successMap.put("success", true);
+      return successMap;
+    }).exceptionally((ex) -> {
+      // Else, auto-rollback when connection closes
+      logger.error("Executed exceptionally: upsertCatalog()", ex);
+      throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage(), ex);
+    });
 
   }
 

--- a/src/main/java/com/hyperlocal/server/ShopController.java
+++ b/src/main/java/com/hyperlocal/server/ShopController.java
@@ -86,13 +86,17 @@ public class ShopController {
   }
 
   @GetMapping("/api/shops/multiple")
-  public CompletableFuture<List<ShopDetails>> getShopsByShopIDBatch() {
+  public CompletableFuture<List<ShopDetails>> getShopsByShopIDBatch(@RequestBody String shopIdListInput) {
+    JsonObject jsonPayload = JsonParser.parseString(shopIdListInput).getAsJsonObject();
+    JsonArray jsonArray = jsonPayload.getAsJsonArray("idlist");
+
     List<ShopDetails> shopsList = new ArrayList<ShopDetails>();
 
     List<Long> shopIDList = new ArrayList<Long>();
-    shopIDList.add(1L);
-    shopIDList.add(2L);
-    shopIDList.add(3L);
+
+    for (JsonElement id: jsonArray){
+      shopIDList.add(id.getAsLong());
+    }
 
     HashMap<Long, Shop> mapShopIdtoShop = new HashMap<Long, Shop>();
     HashMap<String, Merchant> mapMerchantIdToMerchant = new HashMap<String, Merchant>();;

--- a/src/main/java/com/hyperlocal/server/ShopController.java
+++ b/src/main/java/com/hyperlocal/server/ShopController.java
@@ -63,7 +63,7 @@ public class ShopController {
 
   // Fetch all shops by merchantID
   @GetMapping("/api/merchant/{merchantID}/shops")
-  public CompletableFuture<List<Shop>> getShopsByMerchantID(@PathVariable Long merchantID) {
+  public CompletableFuture<List<Shop>> getShopsByMerchantID(@PathVariable String merchantID) {
     List<Shop> shopsList = new ArrayList<Shop>();
 
     CompletableFuture<List<Shop>> shopsPromise = connection

--- a/src/test/java/com/hyperlocal/server/MerchantControllerTest.java
+++ b/src/test/java/com/hyperlocal/server/MerchantControllerTest.java
@@ -25,7 +25,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 public class MerchantControllerTest {
 
-  Merchant merchant = new Merchant(4L, "Test Merchant", "7867986767");
+  Merchant merchant = new Merchant("4", "Test Merchant", "7867986767");
   private final String MERCHANT_DATA_AS_STRING = new Gson().toJson(merchant);
   private JsonObject merchantJson = JsonParser.parseString(MERCHANT_DATA_AS_STRING).getAsJsonObject();
   private static final String MERCHANT_UPDATE_STATEMENT = "UPDATE `Merchants` SET `MerchantName` = ?, `MerchantPhone` = ? WHERE `MerchantID`= ?;";

--- a/src/test/java/com/hyperlocal/server/ShopControllerTest.java
+++ b/src/test/java/com/hyperlocal/server/ShopControllerTest.java
@@ -32,7 +32,7 @@ import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
 
 public class ShopControllerTest {
 
-  private final Shop shop = new Shop(3L, 4L, "Test Shop", 43.424234, 43.4242444, "S-124", "Test");
+  private final Shop shop = new Shop(3L, "4", "Test Shop", 43.424234, 43.4242444, "S-124", "Test");
   private final String SHOP_DATA_AS_STRING = new Gson().toJson(shop);
   private static final String SHOP_UPDATE_STATEMENT = "UPDATE `Shops` SET `ShopName` = ?, `TypeOfService`=?, `Latitude` = ?, `Longitude` = ?, `AddressLine1` = ? WHERE `ShopID`=?;";
   private static final String SHOP_INSERT_STATEMENT = "INSERT INTO `Shops` (`ShopName`, `TypeOfService`, `Latitude`, `Longitude`, `AddressLine1`, `MerchantID`) VALUES (?,?,?,?,?,?);";;
@@ -62,11 +62,11 @@ public class ShopControllerTest {
 
     /* ARRANGE */
     assertThat(controller).isNotNull();
-    Long merchantID = 1000000000000L;
+    String merchantID = "1000000000000";
 
     RowData shopRecord = new FakeRowData(
       "ShopID", 1L, 
-      "MerchantID", 1000000000000L, 
+      "MerchantID", "1000000000000", 
       "ShopName", "Arvind Shop", 
       "Latitude", new BigDecimal(23.33), 
       "Longitude", new BigDecimal(23.33), 
@@ -97,7 +97,7 @@ public class ShopControllerTest {
 
     Long shopID = 1000000000000L;
 
-    Long merchantID = 2000000000000L;
+    String merchantID = "2000000000000";
     RowData shopRecord = new FakeRowData(
       "ShopID", shopID, 
       "MerchantID", merchantID, 


### PR DESCRIPTION
Changed merchantID's datatype to String. This is because the SUB returned by the Identity API can be as large as 30 digits long which does not fit into Integer datatype.