### PR TITLE
feat: allow regd merchants to update shop/cataog + fixes

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -9,9 +9,12 @@ import ViewShops from './Pages/Customer/ViewShops';
 import BuyerCatalog from './Pages/Customer/BuyerCatalog';
 
 // Merchant Pages
-import ShopDetails from './Pages/Merchant/Onboarding/ShopDetails';
-import Catalog from './Pages/Merchant/Onboarding/Catalog';
+import OnboardingShopDetails from './Pages/Merchant/Onboarding/ShopDetails';
+import OnboardingCatalog from './Pages/Merchant/Onboarding/Catalog';
 import MyDashboard from './Pages/Merchant/My/Dashboard';
+import MyShopDetails from './Pages/Merchant/My/ShopDetails';
+import MyCatalog from './Pages/Merchant/My/Catalog';
+
 
 class App extends React.Component {
   constructor(props) {
@@ -68,10 +71,12 @@ class App extends React.Component {
               <ViewShops setLocation={this.setLocation} latitude={this.state.latitude} longitude={this.state.longitude} />
             </Route>
             <Route path={ROUTES.customer.catalog} component={BuyerCatalog} />
-            <Route path={ROUTES.merchant.onboarding.shopInfo} render={(props) => <ShopDetails {...props} setShop={this.setShop} user={this.state.user} />} />
-            <Route path={ROUTES.merchant.onboarding.catalog} render={(props) => <Catalog {...props} user={this.state.user} />} />
+            <Route path={ROUTES.merchant.onboarding.shopInfo} render={(props) => <OnboardingShopDetails {...props} setShop={this.setShop} user={this.state.user} />} />
+            <Route path={ROUTES.merchant.onboarding.catalog} render={(props) => <OnboardingCatalog {...props} user={this.state.user} />} />
             <Route path={ROUTES.merchant.dashboard} render={(props) => <MyDashboard {...props} user={this.state.user} />} />
-          </Switch>
+            <Route path={ROUTES.merchant.shopInfo} render={(props) => <MyShopDetails {...props} setShop={this.setShop} user={this.state.user} />} />
+            <Route path={ROUTES.merchant.catalog} render={(props) => <MyCatalog {...props} user={this.state.user} />} />
+         </Switch>
         </Router>
       </>
     );

--- a/frontend/src/Components/CatalogInput.js
+++ b/frontend/src/Components/CatalogInput.js
@@ -20,8 +20,8 @@ class CatalogInput extends React.Component {
             'serviceDescription': '',
             'serviceImageURL': '',  
         },
-        catalog : [],
-        initialCatalog: []
+        catalog : JSON.parse(JSON.stringify(this.props.value)), // Deep copy
+        initialCatalog: this.props.value
     };
   }
 
@@ -249,5 +249,6 @@ class CatalogInput extends React.Component {
 
 CatalogInput.defaultProps = {
   submit: "Submit",
+  value: []
 };
 export default CatalogInput;

--- a/frontend/src/Components/CatalogInput.js
+++ b/frontend/src/Components/CatalogInput.js
@@ -116,25 +116,28 @@ class CatalogInput extends React.Component {
   }
 
   addNewServiceImageURL = (e) => {
+    const serviceImageURL = e.target.value;
     this.setState(state => {
         let addForm = state.addForm;
-        addForm.serviceImageURL = e.target.value;
+        addForm.serviceImageURL = serviceImageURL;
         return { addForm };
     });
   }
 
   addNewServiceDescription = (e) => {
+    const serviceDescription = e.target.value;
     this.setState(state => {
         let addForm = state.addForm;
-        addForm.serviceDescription = e.target.value;
+        addForm.serviceDescription = serviceDescription;
         return { addForm };
     });
   }
 
   addNewServiceName = (e) => {
+    const serviceName = e.target.value;
     this.setState(state => {
         let addForm = state.addForm;
-        addForm.serviceName = e.target.value;
+        addForm.serviceName = serviceName;
         return { addForm };
     });
   }

--- a/frontend/src/Pages/Merchant/My/Catalog.js
+++ b/frontend/src/Pages/Merchant/My/Catalog.js
@@ -20,7 +20,7 @@ class Catalog extends React.Component {
   }
 
   resetAndReloadServices = () => {
-    return axios.get(ROUTES.api.get.shopByShopID.replace(":shopID", this.props.user.shop.shopID))
+    return axios.get(ROUTES.v1.get.shopByShopID.replace(":shopID", this.props.user.shop.shopID))
     .then(res => {
       if(!("catalog" in res.data))
           throw new Error(res.data.error);

--- a/frontend/src/Pages/Merchant/My/Catalog.js
+++ b/frontend/src/Pages/Merchant/My/Catalog.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import axios from 'axios';
+import ROUTES from '../../../routes';
+import { Container } from 'react-bootstrap';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faSpinner } from '@fortawesome/free-solid-svg-icons'
+
+class Catalog extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+        pageLoading: true,
+        initialCatalog: []
+    };
+  }
+
+  componentDidMount() {
+    return this.resetAndReloadServices();
+  }
+
+  resetAndReloadServices = () => {
+    return axios.get(ROUTES.api.get.shopByShopID.replace(":shopID", this.props.user.shop.shopID))
+    .then(res => {
+      if(!("catalog" in res.data))
+          throw new Error(res.data.error);
+      let initialCatalog = res.data.catalog;
+      initialCatalog.forEach((item, index) => {
+        item.key = index.toString();
+        item.serviceImageURL = item.imageURL;
+      });
+      this.setState({ initialCatalog, pageLoading: false });
+      return;
+    })
+    .catch(err => {
+        console.log(err);
+        alert("Whoops, something went wrong. Trying again...");
+        return this.resetAndReloadServices();
+    });
+  }
+
+  setCatalog = ({ itemsToCreate, itemsToUpdate, itemsToDelete }) => {
+    this.setState({pageLoading: true});
+
+    if(!itemsToCreate.length && !itemsToUpdate.length && !itemsToDelete.length) return this.props.history.push(ROUTES.merchant.dashboard);
+
+    axios.post(ROUTES.v1.post.updateCatalog.replace(":shopID", this.props.user.shop.shopID), {
+      add: itemsToCreate,
+      edit: itemsToUpdate,
+      delete: itemsToDelete
+    })
+    .then(resp => {
+      if(resp.data.success) return this.props.history.push(ROUTES.merchant.dashboard);
+      else alert(resp.data.error);
+    })
+    .catch(ex => {
+      console.log(ex);
+    });
+  }
+
+  render() {
+    return (
+      <Container className="mb-5">
+        <h3 className="h3 mt-5 mb-4">My Catalog</h3>
+        <p>Update or add new services</p>
+        <hr />
+        {
+            this.state.pageLoading
+            ? <div className="text-center mt-5"><FontAwesomeIcon icon={faSpinner} size="3x" /></div>
+            : <CatalogInput value={this.state.initialCatalog} setCatalog={this.setCatalog} />
+        }
+      </Container>
+    );
+  }
+
+}
+
+export default Catalog;

--- a/frontend/src/Pages/Merchant/My/Catalog.js
+++ b/frontend/src/Pages/Merchant/My/Catalog.js
@@ -20,7 +20,7 @@ class Catalog extends React.Component {
   }
 
   resetAndReloadServices = () => {
-    return axios.get(ROUTES.v1.get.shopByShopID.replace(":shopID", this.props.user.shop.shopID))
+    return axios.get(ROUTES.v1.get.shopByShopID.replace("%b", this.props.user.shop.shopID))
     .then(res => {
       if(!("catalog" in res.data))
           throw new Error(res.data.error);

--- a/frontend/src/Pages/Merchant/My/Catalog.js
+++ b/frontend/src/Pages/Merchant/My/Catalog.js
@@ -4,6 +4,7 @@ import ROUTES from '../../../routes';
 import { Container } from 'react-bootstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faSpinner } from '@fortawesome/free-solid-svg-icons'
+import CatalogInput from '../../../Components/CatalogInput';
 
 class Catalog extends React.Component {
   constructor(props) {

--- a/frontend/src/Pages/Merchant/My/ShopDetails.js
+++ b/frontend/src/Pages/Merchant/My/ShopDetails.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import axios from 'axios';
+import { Container } from 'react-bootstrap';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faSpinner } from '@fortawesome/free-solid-svg-icons'
+import ROUTES from '../../../routes';
+import ShopDetailsInput from '../../../Components/ShopDetailsInput';
+
+class ShopDetails extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+        pageLoading: false,
+    };
+  }
+
+  setShopDetails = (shop) => {
+    this.setState({pageLoading: true});
+    axios.put(ROUTES.api.put.updateShop.replace(":merchantID", this.props.user.ID).replace(":shopID", this.props.user.shop.shopID), {
+      shopName: shop.shopName,
+      typeOfService: shop.typeOfService,
+      addressLine1: shop.addressLine1,
+      latitude: shop.latitude,
+      longitude: shop.longitude      
+    })
+    .then(resp => {
+      if("shopID" in resp.data) {
+        this.props.setShop(resp.data);
+        return this.props.history.push(ROUTES.merchant.dashboard);
+      }
+      else throw new Error(resp.data.error);
+    })
+    .catch(ex => {
+      console.log(ex);
+      this.setState({pageLoading: false});
+    });
+  }
+
+  render() {
+    return (
+        <Container>
+          <h3 className="h3 my-5">Seller Details</h3>
+          {
+              this.state.pageLoading 
+              ? <div className="text-center mt-5"><FontAwesomeIcon icon={faSpinner} size="3x" /></div>
+              : <ShopDetailsInput value={this.props.user.shop} setShopDetails={this.setShopDetails} />
+          }
+        </Container>
+    );
+  }
+}
+
+export default ShopDetails;

--- a/frontend/src/Pages/Merchant/My/ShopDetails.js
+++ b/frontend/src/Pages/Merchant/My/ShopDetails.js
@@ -16,7 +16,7 @@ class ShopDetails extends React.Component {
 
   setShopDetails = (shop) => {
     this.setState({pageLoading: true});
-    axios.put(ROUTES.api.put.updateShop.replace(":merchantID", this.props.user.ID).replace(":shopID", this.props.user.shop.shopID), {
+    axios.put(ROUTES.v1.put.updateShop.replace(":merchantID", this.props.user.ID).replace(":shopID", this.props.user.shop.shopID), {
       shopName: shop.shopName,
       typeOfService: shop.typeOfService,
       addressLine1: shop.addressLine1,

--- a/frontend/src/Pages/Merchant/Onboarding/Catalog.js
+++ b/frontend/src/Pages/Merchant/Onboarding/Catalog.js
@@ -19,7 +19,7 @@ class Catalog extends React.Component {
     
     if(!itemsToCreate.length && !itemsToUpdate.length && !itemsToDelete.length) return this.props.history.push(ROUTES.merchant.dashboard);
     
-    axios.put(ROUTES.v1.put.updateCatalog.replace(":merchantID", this.props.user.ID).replace(":shopID", this.props.user.shop.shopID), {
+    axios.post(ROUTES.v1.post.updateCatalog.replace(":shopID", this.props.user.shop.shopID), {
       create: itemsToCreate,
       update: itemsToUpdate,
       delete: itemsToDelete

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -22,6 +22,9 @@ const ROUTES = {
             'insertMerchant': base + '/v1/merchants',
             'insertShop': base + '/v1/merchants/:merchantID/shops',
             'updateCatalog': base + '/v1/shops/:shopID/catalog:batchUpdate'
+        },
+        'put': {
+            'updateShop': base + '/v1/merchants/:merchantID/shops/:shopID'
         }
     },
     'customer': {

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -11,14 +11,14 @@ const ROUTES = {
         }
     },
     'v1': {
-        'get':{
+        'get': {
             'shopsByMerchantID': base + '/v1/merchants/%b/shops',
             'index': {
               'search': base + '/v1/shops/'
             },
             'shopByShopID': base + '/v1/shops/%b'
         },
-        'post':{
+        'post': {
             'insertMerchant': base + '/v1/merchants',
             'insertShop': base + '/v1/merchants/:merchantID/shops',
             'updateCatalog': base + '/v1/shops/:shopID/catalog:batchUpdate'

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -20,7 +20,8 @@ const ROUTES = {
         },
         'post':{
             'insertMerchant': base + '/v1/merchants',
-            'insertShop': base + '/v1/merchants/:merchantID/shops'
+            'insertShop': base + '/v1/merchants/:merchantID/shops',
+            'updateCatalog': base + '/v1/shops/:shopID/catalog:batchUpdate'
         }
     },
     'customer': {


### PR DESCRIPTION
Onboarded merchants can now update their shop details (name, location, etc.) and their offerings via screens accessible through the dashboard.

Other fix: undefined route reference + incorrect HTTP method for network calls during merchant onboarding.