### PR TITLE
feat: allow buyers to change their location + add spinner

### DIFF
--- a/frontend/src/Pages/Customer/BuyerCatalog.js
+++ b/frontend/src/Pages/Customer/BuyerCatalog.js
@@ -2,6 +2,8 @@ import React from 'react';
 import axios from 'axios';
 import { Row, Col, Button, Container, Jumbotron, Card, Image, ListGroup } from 'react-bootstrap';
 import ROUTES from '../../routes';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faSpinner } from '@fortawesome/free-solid-svg-icons'
 
 const CALL_BUTTON_IMAGE_URL = "/images/call.png";
 
@@ -31,10 +33,7 @@ class BuyerCatalog extends React.Component {
   render() {
     if (this.state.shopFetched === false) {
       return (
-        <Container className="p-0 ">
-          <Jumbotron>
-          </Jumbotron>
-        </Container>
+        <div className="text-center mt-5"><FontAwesomeIcon icon={faSpinner} size="3x" /></div>
       );
     } else {
       return (

--- a/frontend/src/Pages/Customer/ViewShops.js
+++ b/frontend/src/Pages/Customer/ViewShops.js
@@ -134,7 +134,7 @@ class ViewShops extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.latitude !== prevProps.latitude || (this.props.longitude !== prevProps.longitude)) {
+    if (this.props.latitude != null && (this.props.latitude !== prevProps.latitude || this.props.longitude !== prevProps.longitude)) {
       this.search();
     }
   }

--- a/frontend/src/Pages/Customer/ViewShops.js
+++ b/frontend/src/Pages/Customer/ViewShops.js
@@ -131,6 +131,9 @@ class ViewShops extends React.Component {
       latitude: null,
       longitude: null
     });
+    this.setState({
+      showModal: true
+    });
   }
 
   componentDidUpdate(prevProps) {

--- a/frontend/src/Pages/Customer/ViewShops.js
+++ b/frontend/src/Pages/Customer/ViewShops.js
@@ -126,6 +126,13 @@ class ViewShops extends React.Component {
     return (angleBetweenCoordinatesInRadians * EARTH_RADIUS_IN_KM).toFixed(2);
   }
 
+  changeLocation = () => {
+    this.props.setLocation({
+      latitude: null,
+      longitude: null
+    });
+  }
+
   componentDidUpdate(prevProps) {
     if (this.props.latitude !== prevProps.latitude || (this.props.longitude !== prevProps.longitude)) {
       this.search();
@@ -148,6 +155,7 @@ class ViewShops extends React.Component {
         this.state.pageLoading
           ? <div className="text-center mt-5"><FontAwesomeIcon icon={faSpinner} size="3x" /></div>
           : <Container className="mt-1 p-3">
+            <Button variant="primary" onClick={this.changeLocation} block> Change Location</Button>
             <Form onSubmit={(e) => { e.preventDefault(); this.search(); }}>
               <Form.Row className="align-items-center">
                 <Col xs={7}>

--- a/frontend/src/Pages/Customer/ViewShops.js
+++ b/frontend/src/Pages/Customer/ViewShops.js
@@ -158,7 +158,7 @@ class ViewShops extends React.Component {
         this.state.pageLoading
           ? <div className="text-center mt-5"><FontAwesomeIcon icon={faSpinner} size="3x" /></div>
           : <Container className="mt-1 p-3">
-            <Button variant="primary" onClick={this.changeLocation} block> Change Location</Button>
+            <Button variant="primary" className="mb-2" onClick={this.changeLocation} block> Change Location</Button>
             <Form onSubmit={(e) => { e.preventDefault(); this.search(); }}>
               <Form.Row className="align-items-center">
                 <Col xs={7}>


### PR DESCRIPTION
1. Buyers can now reset their location. 
![image](https://user-images.githubusercontent.com/29699933/87909564-1b429c00-ca86-11ea-83cd-ab05dd840953.png)

2. Buyers now see a spinner when a shop's catalog is being loaded.